### PR TITLE
Allow head_rep to be enabled via attribute

### DIFF
--- a/attributes/vxrd.rb
+++ b/attributes/vxrd.rb
@@ -1,3 +1,4 @@
 default['vxfld']['vxrd']['packages'] = ['vxfld']
 default['vxfld']['vxrd']['svcnode_ip'] = ''
 default['vxfld']['vxrd']['src_ip'] = node['ipaddress']
+default['vxfld']['vxrd']['head_rep'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'david.wahlstrom@dreamhost.com'
 license 'Apache 2.0'
 description 'Cumulus\'s VXLAN BUM flooding suite.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.8'
+version '0.1.9'
 
 recipe 'vxsnd', ''
 recipe 'vxrd', ''

--- a/templates/default/vxrd.conf.erb
+++ b/templates/default/vxrd.conf.erb
@@ -43,4 +43,4 @@ src_ip =  <%= node["vxfld"]["vxrd"]["src_ip"] %>
 # Enable self replication
 # Note: Use true, or on, for True and 0, no, false, or off,
 # for False
-head_rep = false
+head_rep = <%= node["vxfld"]["vxrd"]["head_rep"] %>


### PR DESCRIPTION
Adds node['vxfld']['vxrd']['head_rep'] . Defaults to false
